### PR TITLE
Add extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "extra": {
     "typo3/cms": {
-      "calendarize-address": "calendarize_address"
+      "extension-key": "calendarize_address"
     }
   }
 }


### PR DESCRIPTION
It is now mandatory to specify the "extension-key" in the extra
section of composer.json

----

Not doing so will result in a warning:

The TYPO3 extension package "fab/rss-display", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
